### PR TITLE
Improve student activity registration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Remember, it's self-paced so feel free to take a break! ☕️
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/elizarovkonst-mcr/skills-getting-started-with-github-copilot/issues/1)
 
 ---
+## Testing 📦
 
+Backend tests live in the `tests/` directory and are powered by **pytest**. To run them locally:
+
+```bash
+pip install -r requirements.txt   # ensures pytest is available
+pytest -q
+```
+
+All tests exercise the FastAPI app under `src/app.py` and reset global state between cases.
+
+---
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,20 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.post("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Make sure the student is currently signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for intramural leagues",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Tennis training and friendly matches",
+        "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+        "max_participants": 8,
+        "participants": ["jordan@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Theater productions and acting workshops",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Explore physics, chemistry, and biology through experiments",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 18,
+        "participants": ["lucas@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop critical thinking and public speaking skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["mason@mergington.edu", "chloe@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,12 +20,55 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        // build participants list HTML if any are signed up
+        let participantsHTML = '';
+        if (details.participants && details.participants.length > 0) {
+          participantsHTML = '<p><strong>Participants:</strong></p>' +
+            '<ul class="participants-list">';
+          details.participants.forEach(email => {
+            // include delete icon with data attributes
+            participantsHTML += `<li>${email} <span class="delete-icon" data-activity="${name}" data-email="${email}">&times;</span></li>`;
+          });
+          participantsHTML += '</ul>';
+        }
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsHTML}
         `;
+
+        // attach click listeners to the delete icons
+        activityCard.querySelectorAll('.delete-icon').forEach(icon => {
+          icon.addEventListener('click', async () => {
+            const email = icon.dataset.email;
+            const activity = icon.dataset.activity;
+            try {
+              const resp = await fetch(
+                `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+                { method: 'POST' }
+              );
+              const result = await resp.json();
+              if (resp.ok) {
+                messageDiv.textContent = result.message;
+                messageDiv.className = 'success';
+                // refresh the activity list so UI updates
+                fetchActivities();
+              } else {
+                messageDiv.textContent = result.detail || 'Failed to unregister';
+                messageDiv.className = 'error';
+              }
+            } catch (err) {
+              messageDiv.textContent = 'Error unregistering participant';
+              messageDiv.className = 'error';
+              console.error(err);
+            }
+            messageDiv.classList.remove('hidden');
+            setTimeout(() => messageDiv.classList.add('hidden'), 5000);
+          });
+        });
 
         activitiesList.appendChild(activityCard);
 
@@ -62,6 +105,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // refresh activities so new participant shows up immediately
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,32 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.activity-card .participants-list {
+  list-style-type: none; /* hide bullets */
+  margin: 5px 0 10px 0;
+  padding-left: 0;
+}
+
+.activity-card .participants-list li {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 3px;
+  display: flex;
+  align-items: center;
+}
+
+.activity-card .participants-list li .delete-icon {
+  margin-left: 8px;
+  color: #c62828;
+  cursor: pointer;
+  font-weight: bold;
+}
+.activity-card .participants-list li {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 3px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,7 @@ client = TestClient(app)
 def test_root_redirect():
     # Arrange is covered by client fixture above
     # Act - do not follow redirects so we can inspect status code
-    response = client.get("/", allow_redirects=False)
+    response = client.get("/", follow_redirects=False)
     # Assert
     assert response.status_code in (307, 302)
     assert response.headers["location"] == "/static/index.html"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,88 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import app, activities
+
+# keep a pristine copy of the data so tests can restore state
+_original_activities = deepcopy(activities)
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    # Arrange: before each test, reset global activities dict
+    activities.clear()
+    activities.update(deepcopy(_original_activities))
+
+
+client = TestClient(app)
+
+
+def test_root_redirect():
+    # Arrange is covered by client fixture above
+    # Act - do not follow redirects so we can inspect status code
+    response = client.get("/", allow_redirects=False)
+    # Assert
+    assert response.status_code in (307, 302)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities():
+    # Act
+    response = client.get("/activities")
+    # Assert
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    # check a couple of known keys from the original data
+    assert "Chess Club" in data
+    assert "Gym Class" in data
+
+
+def test_signup_success():
+    email = "newstudent@mergington.edu"
+    # Act
+    response = client.post("/activities/Chess Club/signup", params={"email": email})
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert "Signed up" in body.get("message", "")
+    assert email in activities["Chess Club"]["participants"]
+
+
+def test_signup_duplicate():
+    existing = _original_activities["Chess Club"]["participants"][0]
+    # Act
+    response = client.post("/activities/Chess Club/signup", params={"email": existing})
+    # Assert
+    assert response.status_code == 400
+
+
+def test_signup_not_found():
+    email = "ghost@mergington.edu"
+    response = client.post("/activities/Nonexistent/signup", params={"email": email})
+    assert response.status_code == 404
+
+
+def test_unregister_success():
+    # Arrange: ensure someone is signed up; use one from original
+    email = _original_activities["Gym Class"]["participants"][0]
+    # Act
+    response = client.post("/activities/Gym Class/unregister", params={"email": email})
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert "Unregistered" in body.get("message", "")
+    assert email not in activities["Gym Class"]["participants"]
+
+
+def test_unregister_not_signed():
+    email = "nobody@mergington.edu"
+    response = client.post("/activities/Chess Club/unregister", params={"email": email})
+    assert response.status_code == 400
+
+
+def test_unregister_not_found():
+    email = "whatever@mergington.edu"
+    response = client.post("/activities/Nope/unregister", params={"email": email})
+    assert response.status_code == 404


### PR DESCRIPTION
This pull request introduces backend and frontend support for unregistering participants from activities, expands the activity dataset, and adds comprehensive backend tests. It also improves the UI to display participants and manage their removal, and documents testing instructions in the `README.md`.

**Backend enhancements:**

* Added a new endpoint `POST /activities/{activity_name}/unregister` to allow removal of a participant from an activity, including validation for participant presence and activity existence. (`src/app.py`)
* Expanded the `activities` dataset with several new clubs and teams, each with descriptions, schedules, and participants. (`src/app.py`)

**Frontend improvements:**

* Updated the activity cards to display a list of participants with a delete icon for each, enabling removal of participants directly from the UI. (`src/static/app.js`)
* Refreshed the activity list after signup and unregister actions to ensure immediate UI updates. (`src/static/app.js`)
* Added CSS styles for the participants list and delete icon to enhance visual clarity and usability. (`src/static/styles.css`)

**Testing and documentation:**

* Added a `tests/test_app.py` file with pytest-based tests covering signup, unregister, and error cases, including fixture to reset global state between tests.
* Included a new section in the `README.md` describing how to run backend tests locally using pytest.